### PR TITLE
[DEV-394] loop through files

### DIFF
--- a/.github/workflows/check_workflow_versions.yml
+++ b/.github/workflows/check_workflow_versions.yml
@@ -33,6 +33,10 @@ jobs:
               job_keys = Object.keys(data['jobs'])
 
               for (const element of job_keys) {
+                if (typeof data['jobs'][element]['uses'] == 'undefined') {
+                  console.log(`data['jobs'][${job_keys}]['uses']`+'is undefined')
+                  continue
+                }
                 owner = data['jobs'][element]['uses'].split('/')[0]
                 repo = data['jobs'][element]['uses'].split('/')[1]
                 var releases  = await github.rest.repos.listReleases({

--- a/.github/workflows/check_workflow_versions.yml
+++ b/.github/workflows/check_workflow_versions.yml
@@ -34,7 +34,7 @@ jobs:
 
               for (const element of job_keys) {
                 if (typeof data['jobs'][element]['uses'] == 'undefined') {
-                  console.log(`data['jobs'][${job_keys}]['uses']`+'is undefined')
+                  console.log(`data['jobs'][${job_keys}]['uses']`+' is undefined, skipping...')
                   continue
                 }
                 owner = data['jobs'][element]['uses'].split('/')[0]

--- a/.github/workflows/check_workflow_versions.yml
+++ b/.github/workflows/check_workflow_versions.yml
@@ -2,11 +2,6 @@
 name: check workflow version
 on:
   workflow_call:
-    inputs:
-      gha-workflow-file-name:
-        description: The name of the reusable workflow github actions file.
-        required: true
-        type: string
 
 jobs:
   build:
@@ -49,7 +44,7 @@ jobs:
                 releases = releases.filter(x => x.draft != true)
                 latest_major_release = releases[0].tag_name.split(".")[0]
                 current_version = data['jobs'][element]['uses'].split('/')[4].split('@')[1]
-                workflow_versions[element] = {'latest_major_release': latest_major_release, 'current_version': current_version}
+                workflow_versions[element] = {'latest_major': latest_major_release, 'current_major': current_version}
 
                 if (workflow_versions[element]['latest_major_release'] != workflow_versions[element]['current_version']) {
                   console.log(element+'version mismatch, adding to outdated_workflows array')

--- a/.github/workflows/check_workflow_versions.yml
+++ b/.github/workflows/check_workflow_versions.yml
@@ -29,31 +29,37 @@ jobs:
           script: |
             const yaml = require('js-yaml')
             const fs = require('fs')
-            const data = yaml.load(fs.readFileSync(".github/workflows/${{ env.FILE_NAME }}", 'utf8'))
             var workflow_versions = {}
             var outdated_workflows = []
-            job_keys = Object.keys(data['jobs'])
+            var files = fs.readdirSync('.github/workflows/');
 
-            for (const element of job_keys) {
-              owner = data['jobs'][element]['uses'].split('/')[0]
-              repo = data['jobs'][element]['uses'].split('/')[1]
-              var releases  = await github.rest.repos.listReleases({
-                owner: owner,
-                repo: repo,
-              })
-              releases = releases.data
-              releases = releases.filter(x => x.prerelease != true)
-              releases = releases.filter(x => x.draft != true)
-              latest_major_release = releases[0].tag_name.split(".")[0]
-              current_version = data['jobs'][element]['uses'].split('/')[4].split('@')[1]
-              workflow_versions[element] = {'latest_major_release': latest_major_release, 'current_version': current_version}
+            for (const file_name of files) {
+              data = yaml.load(fs.readFileSync(`.github/workflows/${file_name}`, 'utf8'))
+              job_keys = Object.keys(data['jobs'])
 
-              if (workflow_versions[element]['latest_major_release'] != workflow_versions[element]['current_version']) {
-                console.log(element+'version mismatch, adding to outdated_workflows array')
-                outdated_workflows.push({ [element] : workflow_versions['check-workflow-version']})
+              for (const element of job_keys) {
+                owner = data['jobs'][element]['uses'].split('/')[0]
+                repo = data['jobs'][element]['uses'].split('/')[1]
+                var releases  = await github.rest.repos.listReleases({
+                  owner: owner,
+                  repo: repo,
+                })
+                releases = releases.data
+                releases = releases.filter(x => x.prerelease != true)
+                releases = releases.filter(x => x.draft != true)
+                latest_major_release = releases[0].tag_name.split(".")[0]
+                current_version = data['jobs'][element]['uses'].split('/')[4].split('@')[1]
+                workflow_versions[element] = {'latest_major_release': latest_major_release, 'current_version': current_version}
+
+                if (workflow_versions[element]['latest_major_release'] != workflow_versions[element]['current_version']) {
+                  console.log(element+'version mismatch, adding to outdated_workflows array')
+                  outdated_workflows.push({ [element] : workflow_versions['check-workflow-version']})
+                }
               }
             }
-
+            console.log('workflow versions')
+            console.log(workflow_versions)
+            console.log('outdated_workflows')
             console.log(outdated_workflows)
 
             if (outdated_workflows.length > 0) {

--- a/.github/workflows/workflow_version_check.yml
+++ b/.github/workflows/workflow_version_check.yml
@@ -8,10 +8,4 @@ on:
 
 jobs:
   check-workflow-version:
-    uses: vergesense/gha-check-workflow-versions/.github/workflows/check_workflow_versions.yml@v1
-    with:
-      gha-workflow-file-name: ci.yml
-  check-workflow-version2:
-    uses: vergesense/gha-check-workflow-versions/.github/workflows/check_workflow_versions.yml@v1
-    with:
-      gha-workflow-file-name: workflow_version_check.yml
+    uses: vergesense/gha-check-workflow-versions/.github/workflows/check_workflow_versions.yml@DEV-394


### PR DESCRIPTION
The yaml structure of a reusable workflow is unique in that it goes `[jobs][uses]` whereas normal workflows are structured as `[jobs][runs-on]` to indicate the runtime.  The simple method of exclusion should work for most, if not all, reusable workflows and exclude "normal" workflows.