### PR TITLE
[DEV-394] use new check_workflow_version

### DIFF
--- a/.github/workflows/check_workflow_versions.yml
+++ b/.github/workflows/check_workflow_versions.yml
@@ -8,11 +8,6 @@ jobs:
     name: check workflow latest major version
     runs-on: ubuntu-latest
     steps:
-      - name: set-env-vars
-        run: |
-          {
-            echo "FILE_NAME=${{ inputs.gha-workflow-file-name }}"
-          } >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/workflow_ci.yml
+++ b/.github/workflows/workflow_ci.yml
@@ -4,15 +4,13 @@ name: ci
 on:
   pull_request:
     paths:
-      - '*.ya?ml'
+      - '**.ya?ml'
   push:
     branches:
       - main
     paths:
-      - '*.ya?ml'
+      - '**.ya?ml'
 
 jobs:
   workflow-ci:
     uses: vergesense/gha-workflow-ci/.github/workflows/workflow_ci.yml@v1
-    with:
-      actionlint-ignore: -ignore 'property ".+" is not defined in object type'

--- a/.github/workflows/workflow_ci.yml
+++ b/.github/workflows/workflow_ci.yml
@@ -3,9 +3,13 @@ name: ci
 
 on:
   pull_request:
+    paths:
+      - '*.ya?ml'
   push:
     branches:
       - main
+    paths:
+      - '*.ya?ml'
 
 jobs:
   workflow-ci:

--- a/.github/workflows/workflow_version_check.yml
+++ b/.github/workflows/workflow_version_check.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     types: [opened, reopened]
 
-
 jobs:
   check-workflow-version:
-    uses: vergesense/gha-check-workflow-versions/.github/workflows/check_workflow_versions.yml@DEV-394
+    uses: vergesense/gha-check-workflow-versions/.github/workflows/check_workflow_versions.yml@v1


### PR DESCRIPTION
Configured `workflow_ci` to run on any yaml file update or edit.  If we think running `actionlint` alongside `yamllint` would be too many runs, we can split the workflows out further.  I was hoping to group them all together, but if a non-github-action workflow yaml file is updated, it will run everything.

Alternatively, we could re-add yamllint into other linters, and then configure `workflow_ci` to specifically run on only github workflow files.  This would create a circumstance where if a workflow file is updated, and non-workflow file is updated, we would run yamllint twice. 

The "most targeted" method would be to split actionlint and yamllint into their own reusable workflows, but it feels a bit inefficient creating two repositories which only house one action each.